### PR TITLE
Fix requirements.txt file to a standard format.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,15 @@
-Package         Version
---------------- -------
-blinker         1.4    
-docutils        0.16   
-feedgenerator   1.9    
-Jinja2          2.11.1 
-Markdown        3.1.1  
-MarkupSafe      1.1.1  
-pelican         4.2.0  
-pip             20.0.2 
-Pygments        2.5.2  
-python-dateutil 2.8.1  
-pytz            2019.3 
-setuptools      45.1.0 
-six             1.14.0 
-Unidecode       1.1.1  
-wheel           0.34.2 
+blinker==1.4    
+docutils==0.16   
+feedgenerator==1.9    
+Jinja2==2.11.1 
+Markdown==3.1.1  
+MarkupSafe==1.1.1  
+pelican==4.2.0  
+pip==20.0.2 
+Pygments==2.5.2  
+python-dateutil==2.8.1  
+pytz==2019.3 
+setuptools==45.1.0 
+six==1.14.0 
+Unidecode==1.1.1  
+wheel==0.34.2 


### PR DESCRIPTION
It is now possible to install all required modules with a standard command using requirements.txt file:
`pip install -r requirements.txt`